### PR TITLE
Refactor ardu1 to remove dependencies

### DIFF
--- a/Reflecta.h
+++ b/Reflecta.h
@@ -1,6 +1,4 @@
 #include <Arduino.h>
-#include <Wire.h>
-#include <Servo.h>
 #include <avr/wdt.h>
 
 #ifndef _REFLECTA_H_
@@ -135,22 +133,6 @@ namespace reflectaArduinoCore {
   void digitalWrite();
   void analogRead();
   void analogWrite();
-
-  void wireBeginMaster();
-
-  void wireRequestFrom();
-  void wireRequestFromStart();
-  void wireAvailable();
-  void wireRead();
-
-  void wireBeginTransmission();
-  void wireWrite();
-  void wireEndTransmission();
-
-  void servoAttach();
-  void servoDetach();
-  void servoWrite();
-  void servoWriteMicroseconds();
 
   void pulseIn();
 

--- a/ReflectaArduinoCore.cpp
+++ b/ReflectaArduinoCore.cpp
@@ -33,73 +33,6 @@ namespace reflectaArduinoCore {
     ::analogWrite(pin, val);
   }
 
-  void wireBeginMaster() {
-    Wire.begin();
-  }
-
-  void wireRequestFrom() {
-    int8_t address = reflectaFunctions::pop();
-    int8_t quantity = reflectaFunctions::pop();
-    Wire.requestFrom(address, quantity);
-  }
-
-  void wireRequestFromStart() {
-    int8_t address = reflectaFunctions::pop();
-    int8_t quantity = reflectaFunctions::pop();
-    Wire.requestFrom(address, quantity, false);
-  }
-
-  void wireAvailable() {
-    reflectaFunctions::push(Wire.available());
-  }
-
-  void wireRead() {
-    if (Wire.available())
-    reflectaFunctions::push(Wire.read());
-    else
-      reflectaFrames::sendEvent(reflecta::Error, reflecta::WireNotAvailable);
-  }
-
-  void wireBeginTransmission() {
-    int8_t address = reflectaFunctions::pop();
-    Wire.beginTransmission(address);
-  }
-
-  // TODO(jay): Support variants write(string) and write(data, length)
-  void wireWrite() {
-    int8_t val = reflectaFunctions::pop();
-    Wire.write(val);
-  }
-
-  void wireEndTransmission() {
-    Wire.endTransmission();
-  }
-
-  Servo servos[MAX_SERVOS];
-
-  // TODO(jay): Support variant attach(pin, min, max)
-  void servoAttach() {
-    int8_t pin = reflectaFunctions::pop();
-    servos[pin].attach(pin);
-  }
-
-  void servoDetach() {
-    int8_t pin = reflectaFunctions::pop();
-    servos[pin].detach();
-  }
-
-  void servoWrite() {
-    int8_t pin = reflectaFunctions::pop();
-    int8_t val = reflectaFunctions::pop();
-    servos[pin].write(val);
-  }
-
-  void servoWriteMicroseconds() {
-    int8_t pin = reflectaFunctions::pop();
-    int8_t val = reflectaFunctions::pop16();
-    servos[pin].writeMicroseconds(val);
-  }
-
   // TODO(jay): Support variant pulseIn(pin, value, timeout)
   void pulseIn() {
     // BUGBUG: Broken, returns a 32 bit result
@@ -115,22 +48,6 @@ namespace reflectaArduinoCore {
     reflectaFunctions::bind("ardu1", digitalWrite);
     reflectaFunctions::bind("ardu1", analogRead);
     reflectaFunctions::bind("ardu1", analogWrite);
-
-    reflectaFunctions::bind("ardu1", wireBeginMaster);
-
-    reflectaFunctions::bind("ardu1", wireRequestFrom);
-    reflectaFunctions::bind("ardu1", wireRequestFromStart);
-    reflectaFunctions::bind("ardu1", wireAvailable);
-    reflectaFunctions::bind("ardu1", wireRead);
-
-    reflectaFunctions::bind("ardu1", wireBeginTransmission);
-    reflectaFunctions::bind("ardu1", wireWrite);
-    reflectaFunctions::bind("ardu1", wireEndTransmission);
-
-    reflectaFunctions::bind("ardu1", servoAttach);
-    reflectaFunctions::bind("ardu1", servoDetach);
-    reflectaFunctions::bind("ardu1", servoWrite);
-    reflectaFunctions::bind("ardu1", servoWriteMicroseconds);
 
     reflectaFunctions::bind("ardu1", pulseIn);
   }

--- a/ReflectaServo.cpp
+++ b/ReflectaServo.cpp
@@ -1,0 +1,36 @@
+#include "Reflecta.h"
+#include "ReflectaServo.h"
+
+namespace ReflectaServo {
+  Servo servos[MAX_SERVOS];
+
+  // TODO(jay): Support variant attach(pin, min, max)
+  void servoAttach() {
+    int8_t pin = reflectaFunctions::pop();
+    servos[pin].attach(pin);
+  }
+
+  void servoDetach() {
+    int8_t pin = reflectaFunctions::pop();
+    servos[pin].detach();
+  }
+
+  void servoWrite() {
+    int8_t pin = reflectaFunctions::pop();
+    int8_t val = reflectaFunctions::pop();
+    servos[pin].write(val);
+  }
+
+  void servoWriteMicroseconds() {
+    int8_t pin = reflectaFunctions::pop();
+    int8_t val = reflectaFunctions::pop16();
+    servos[pin].writeMicroseconds(val);
+  }
+
+  void setup() {
+    reflectaFunctions::bind("srvo1", servoAttach);
+    reflectaFunctions::bind("srvo1", servoDetach);
+    reflectaFunctions::bind("srvo1", servoWrite);
+    reflectaFunctions::bind("srvo1", servoWriteMicroseconds);
+  }
+};  // namespace reflectaServo

--- a/ReflectaServo.h
+++ b/ReflectaServo.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Servo.h>
+#include "Reflecta.h"
+
+namespace reflectaServo
+{
+  // basic methods
+  void setup();
+
+  // interface methods
+  void servoAttach();
+  void servoDetach();
+  void servoWrite();
+  void servoWriteMicroseconds();
+}; // namespace reflectaServo

--- a/ReflectaTest.cpp
+++ b/ReflectaTest.cpp
@@ -1,0 +1,28 @@
+#include <Reflecta.h>
+#include "ReflectaTest.h"
+
+namespace reflectaTest
+{
+  bool infinite = false;
+
+  // basic methods
+  void setup()
+  {
+    reflectaFunctions::bind("test1", SetInfinite);
+  }
+
+  void loop()
+  {
+    while (infinite)
+    {
+      delay(100L);
+    }
+  }
+
+  // interface methods
+  void SetInfinite()
+  {
+    infinite = true;
+  }
+};
+

--- a/ReflectaTest.h
+++ b/ReflectaTest.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace reflectaTest
+{
+  // basic methods
+  void setup();
+  void loop();
+
+  // interface methods
+  void SetInfinite();
+};

--- a/ReflectaWire.cpp
+++ b/ReflectaWire.cpp
@@ -1,0 +1,57 @@
+#include "Reflecta.h"
+#include "ReflectaWire.h"
+
+namespace reflectaWire {
+  void wireBeginMaster() {
+    Wire.begin();
+  }
+
+  void wireRequestFrom() {
+    int8_t address = reflectaFunctions::pop();
+    int8_t quantity = reflectaFunctions::pop();
+    Wire.requestFrom(address, quantity);
+  }
+
+  void wireRequestFromStart() {
+    int8_t address = reflectaFunctions::pop();
+    int8_t quantity = reflectaFunctions::pop();
+    Wire.requestFrom(address, quantity, false);
+  }
+
+  void wireAvailable() {
+    reflectaFunctions::push(Wire.available());
+  }
+
+  void wireRead() {
+    if (Wire.available())
+    reflectaFunctions::push(Wire.read());
+    else
+      reflectaFrames::sendEvent(reflecta::Error, reflecta::WireNotAvailable);
+  }
+
+  void wireBeginTransmission() {
+    int8_t address = reflectaFunctions::pop();
+    Wire.beginTransmission(address);
+  }
+
+  // TODO(jay): Support variants write(string) and write(data, length)
+  void wireWrite() {
+    int8_t val = reflectaFunctions::pop();
+    Wire.write(val);
+  }
+
+  void wireEndTransmission() {
+    Wire.endTransmission();
+  }
+
+  void setup() {
+    reflectaFunctions::bind("wire1", wireBeginMaster);
+    reflectaFunctions::bind("wire1", wireRequestFrom);
+    reflectaFunctions::bind("wire1", wireRequestFromStart);
+    reflectaFunctions::bind("wire1", wireAvailable);
+    reflectaFunctions::bind("wire1", wireRead);
+    reflectaFunctions::bind("wire1", wireBeginTransmission);
+    reflectaFunctions::bind("wire1", wireWrite);
+    reflectaFunctions::bind("wire1", wireEndTransmission);
+  }
+};  // namespace reflectaArduinoCore

--- a/ReflectaWire.h
+++ b/ReflectaWire.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Wire.h>
+#include "Reflecta.h"
+
+namespace reflectaWire
+{
+  // basic methods
+  void setup();
+	  
+  // interface methods
+  void wireBeginMaster();
+
+  void wireRequestFrom();
+  void wireRequestFromStart();
+  void wireAvailable();
+  void wireRead();
+
+  void wireBeginTransmission();
+  void wireWrite();
+  void wireEndTransmission();
+}; // namespace reflectaWire

--- a/deploy.cmd
+++ b/deploy.cmd
@@ -1,0 +1,2 @@
+rmdir /S /Q %USERPROFILE%\Documents\Arduino\libraries\Reflecta
+xcopy * %USERPROFILE%\Documents\Arduino\libraries\Reflecta /s /e /i

--- a/examples/BasicIMU/BasicIMU.ino
+++ b/examples/BasicIMU/BasicIMU.ino
@@ -1,5 +1,4 @@
 #include <Wire.h>
-#include <Servo.h>
 #include <L3G.h>
 #include <LSM303.h>
 #include <Reflecta.h>

--- a/examples/StandardReflecta/StandardReflecta.ino
+++ b/examples/StandardReflecta/StandardReflecta.ino
@@ -1,6 +1,4 @@
 #include <Arduino.h>
-#include <Wire.h>
-#include <Servo.h>
 #include <Reflecta.h>
 
 // Very simple Arduino sketch for using reflecta.  Opens a COM port


### PR DESCRIPTION
ardu1 currently contains a blend of arduino methods as well as wire.h and servo.h. Servo.h isn't currently working with reflecta. In general though, many sketches may not need the wire or servo interface. removing the dependency clarifies the intent and reduces risk of conflicts.